### PR TITLE
Fix issue with deleting courses

### DIFF
--- a/api/src/routes/courses.js
+++ b/api/src/routes/courses.js
@@ -72,7 +72,7 @@ promiseRouter.delete('/:id',
   getCourse,
   restrictAccessToCourse,
   async (req, res) => {
-    await db.repository.deleteCourse();
+    await db.repository.deleteCourse(req.params.id);
     noContentResponse(res);
   });
 

--- a/api/src/routes/courses.js
+++ b/api/src/routes/courses.js
@@ -18,6 +18,7 @@ const {
   createdResponse,
   noContentResponse,
   successResponse,
+  badRequestResponse,
 } = require('./helpers');
 const db = require('../db');
 const {
@@ -32,6 +33,7 @@ const {
   restrictAccessToCourse,
 } = courseMiddleware;
 const promiseRouter = new PromiseRouter();
+const mongoose = require('mongoose');
 
 promiseRouter.get('/', async (req, res) => {
   const courses = await db.repository.getCourses();
@@ -72,7 +74,11 @@ promiseRouter.delete('/:id',
   getCourse,
   restrictAccessToCourse,
   async (req, res) => {
-    await db.repository.deleteCourse(req.params.id);
+    if(!mongoose.Types.ObjectId.isValid(req.params.id)){
+      badRequestResponse(res,['ID given is not an ObjectId.']);
+      return;
+    }
+    await db.repository.deleteCourse(mongoose.Types.ObjectId(req.params.id));
     noContentResponse(res);
   });
 


### PR DESCRIPTION
When a delete request was sent, an ID wasn't passed to the method, meaning it didn't know what to delete.

We also have to convert the ID given from a String to an ObjectId before it can be passed on.